### PR TITLE
Fixed small bug for python3 users

### DIFF
--- a/playonlinux-bash
+++ b/playonlinux-bash
@@ -24,6 +24,10 @@
 export SILENT="TRUE"
 SCRIPTNAME="$1"
 shift
+if [ "$PYTHON" = ""]
+then
+	PYTHON="python"
+fi
 if [ "$SCRIPTNAME" = "" ]
 then
 	echo "Usage : playonlinux-bash [script]"
@@ -37,7 +41,7 @@ then
 	CURDIR="$(pwd)"
 	export MACHTYPE
 	cd "$WorkingDirectory"
-	python "$CURDIR/python/wrapper.py" "$SCRIPTNAME" "$@"
+	"$PYTHON" "$CURDIR/python/wrapper.py" "$SCRIPTNAME" "$@"
 else
 	bash "$SCRIPTNAME" "$@"
 fi


### PR DESCRIPTION
When you have python3 is your default python, the playonlinux-bash script will start up the wrong python version (since POL doesn't work too well with python3 yet). But selection of the right python version has already been done in the playonlinux script. So we use the PYTHON env variable to start the selected python version.
