### PR TITLE
Change IRC URL

### DIFF
--- a/python/lib/irc.py
+++ b/python/lib/irc.py
@@ -16,7 +16,7 @@ class IRCClient(threading.Thread):
     string_to_write = ""
     def __init__(self):
         threading.Thread.__init__(self)
-        self.serveur = "irc.freenode.com"
+        self.serveur = "irc.freenode.net"
         self.port = 6667
         self.Nick = Variables.current_user+"-pol"
         self.chanAutoJoin = "#playonlinux"


### PR DESCRIPTION
BUG: http://www.playonlinux.com/en/issue-3264.html

URL for freenode.com is expired. Renamed to irc.freenode.net

Just thought I would try it. I need to get used to github and things like this more. :)
