### PR TITLE
Fixed issue with removing prefixes containing symlinks to unremovable fi...

### DIFF
--- a/python/configure.py
+++ b/python/configure.py
@@ -757,7 +757,7 @@ class MainWindow(wx.Frame):
                     fullpath = os.path.join(dirname, dir)
                     # To speed up the process, only modify metadata when necessary
                     attr = os.stat(fullpath)
-                    if attr.st_mode & needed_dir_rights != needed_dir_rights:
+                    if attr.st_mode & needed_dir_rights != needed_dir_rights and not os.path.islink(fullpath):
                         print "%s rights need fixing" % fullpath
                         os.chmod(fullpath, needed_dir_rights)
 


### PR DESCRIPTION
Prefixes with symlinks to files/directories that can't be removed (e.g. .PlayOnLinux/wineprefix/$PREFIX/dosdevices/d:, which points to a mounted DVD) prevent prefix deletion. Changed the permissions loop to ignore symlinks.
