### PR TITLE
Fix order of parameters in description of POL_SetupWindow_icon_menu

### DIFF
--- a/lib/setupwindow.lib
+++ b/lib/setupwindow.lib
@@ -223,7 +223,7 @@ POL_SetupWindow_menu ()
 POL_SetupWindow_icon_menu ()
 {
 	# Shows a menu with icons
-	# Usage: POL_SetupWindow_icon_menu [message] [title] [list] [separator] [icons list] [icons folder]
+	# Usage: POL_SetupWindow_icon_menu [message] [title] [list] [separator] [icons folder] [icons list]
 	# Result is sent in $APP_ANSWER variable
 
 	APP_ANSWER="$(echo "$POL_COOKIE	POL_SetupWindow_icon_menu	$$	$(POL_Untab "$1")	$(POL_Untab "$2")	$3	$4	$5	$6" | ncns "$POL_HOST" "$POL_PORT")"


### PR DESCRIPTION
https://github.com/PlayOnLinux/POL-POM-4/blob/master/python/guiv3.py#L563
