### PR TITLE
"/run/media/$USER" folder for cdrom

### DIFF
--- a/lib/setupwindow.lib
+++ b/lib/setupwindow.lib
@@ -334,6 +334,8 @@ POL_SetupWindow_cdrom ()
 		DEVICES="/media"
 		# Ubuntu Quantal workaround
 		[ -d "/media/$USER" ] && DEVICES="/media/$USER"
+		# Fedora/Manjaro workaround
+		[ -d "/run/media/$USER" ] && DEVICES="/run/media/$USER"
 	fi
 	
 	cd "$DEVICES"


### PR DESCRIPTION
Adding support for Linux distributions that mount CD in the "/run/media/$USER" folder

these Linux distributions are concerned:
- Fedora
- Manjaro (I think)

There is probably more  (Arch Linux?)

![capture d ecran de 2014-09-05 08 37 08](https://cloud.githubusercontent.com/assets/4596884/4160978/236e2e68-34c7-11e4-9db3-437a2e3398e9.png)
