### PR TITLE
Add documentation to playonlinux

### DIFF
--- a/doc/copyright
+++ b/doc/copyright
@@ -1,0 +1,4 @@
+Copyright 2011 Quentin Pâris <qparis@playonlinux.com>
+Copyright 2011 PlayOnLinux Team <contact@playonlinux.com>
+
+Read /usr/share/common-licenses/GPL-3

--- a/doc/playonlinux-daemon.1
+++ b/doc/playonlinux-daemon.1
@@ -1,0 +1,28 @@
+.TH PLAYONLINUX-DAEMON 1 "February  6, 2009"
+
+.SH NAME
+playonlinux-daemon \- daemon to handle disk insertion in PlayOnLinux
+
+.SH SYNOPSIS
+.B playonlinux-daemon
+.RI [ options ]
+
+.SH DESCRIPTION
+.B playonlinux-daemon
+is a daemon to handle disk insertion within PlayOnLinux. It still needs testing and may not work flawlessly.
+.br
+Users who want to handle autoruns with PlayOnLinux should launch this script at startup.
+
+.SH OPTIONS
+.TP
+.I "--version"
+ Show version number and exit.
+.TP
+.I "--kill"
+ Kill the daemon.
+
+.SH AUTHOR
+playonlinux was written by Quentin Pâris <qparis@playonlinux.com>.
+.PP
+This manual page was written by Bertrand Marc <beberking@gmail.com>,
+for the Debian project (but may be used by others).

--- a/doc/playonlinux-pkg.1
+++ b/doc/playonlinux-pkg.1
@@ -1,0 +1,33 @@
+.TH PLAYONLINUX-PKG 1 "February  6, 2009"
+
+.SH NAME
+playonlinux-pkg \- tool to manage playonlinux packages
+
+.SH SYNOPSIS
+.B playonlinux-pkg
+.RI [ options ]
+.RI [ package ]
+
+.SH DESCRIPTION
+.B playonlinux-pkg
+is a tool to install or manage the playonlinux packages
+
+.SH OPTIONS
+.TP
+.I "-b, --browse"
+ Choose a file.
+.TP
+.I "-e, --extract"
+ Extract the package.
+.TP
+.I "-i, --install"
+ Install the package.
+.TP
+.I "-h, --help"
+ Show usage.
+
+.SH AUTHOR
+playonlinux was written by Quentin Pâris <qparis@playonlinux.com>.
+.PP
+This manual page was written by Bertrand Marc <beberking@gmail.com>,
+for the Debian project (but may be used by others).

--- a/doc/playonlinux.1
+++ b/doc/playonlinux.1
@@ -1,0 +1,33 @@
+.TH PLAYONLINUX 1 "February  6, 2009"
+
+.SH NAME
+PlayOnLinux \- front-end for Wine
+
+.SH SYNOPSIS
+.B playonlinux
+.RI [ options ]
+
+.SH DESCRIPTION
+.B PlayOnLinux
+is a front-end for Wine. It allows you to easily install and use numerous games and softwares designed to run with Microsoft®'s Windows®.
+.br
+Few games are compatible with GNU/Linux at the moment and it certainly is a factor preventing the migration to this system.
+.P
+.B PlayOnLinux
+performs installations in
+.I ~/.PlayOnLinux
+and uses separate Wine prefixes to avoid conflicts between applications.
+
+.SH OPTIONS
+.TP
+.I --version
+ Show version number and exit.
+.TP
+.I "--run <prog>"
+ Run directly the specified program.
+
+.SH AUTHOR
+playonlinux was written by Quentin Pâris <qparis@playonlinux.com>.
+.PP
+This manual page was written by Bertrand Marc <beberking@gmail.com>,
+for the Debian project (but may be used by others).


### PR DESCRIPTION
These are not in playonlinux git and but I found them in the Fedora
package.
Taken from there.

It's good to have manual here for the packaging.