### PR TITLE
Master add makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,8 @@ CFLAGS += -lGL -lX11
 
 sharedir := $(DESTDIR)$(PREFIX)/share
 bindir := $(DESTDIR)$(PREFIX)/bin
+execdir := $(DESTDIR)$(PREFIX)/libexec
+
 
 all: build
 
@@ -54,6 +56,7 @@ build:
 
 install:
 	install -d $(bindir)
+	install -d $(execdir)
 	install -d $(sharedir)/pixmaps
 	install -d $(sharedir)/applications
 	install -d $(sharedir)/playonlinux/bin
@@ -65,6 +68,7 @@ install:
 	cp ./etc/playonlinux16.png $(sharedir)/pixmaps/playonlinux16.png
 	cp ./etc/playonlinux32.png $(sharedir)/pixmaps/playonlinux32.png
 	cp ./bin/{playonlinux,playonlinux-pkg} $(bindir)/
+	cp ./bin/playonlinux-check_dd $(execdir)/
 	cp ./{playonlinux*,README.md,TRANSLATORS,CHANGELOG.md,LICENCE} $(sharedir)/playonlinux/
 	cp -R ./{bash,etc,lang,lib,plugins,python,resources,tests} $(sharedir)/playonlinux/
 

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ clean:
 	$(RM) ./ChangeLog
 
 build:
-	$(CC) ./src/check_direct_rendering.c -o ./bin/check_dd
+	$(CC) ./src/check_direct_rendering.c -o ./bin/playonlinux-check_dd
 	$(PYTHON) ./python/*.py
 	$(PYTHON) ./python/lib/*.py
 	echo -e '#!/bin/bash\n${sharedir}/playonlinux/playonlinux "$$@"\nexit 0' > ./bin/playonlinux

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,74 @@
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:		Jiri Konecny <dragonlichcz@gmail.com>
+
+
+# Arguments:
+#
+# PREFIX  -- Set prefix for the installation (/usr is default)
+# DESTDIR -- Where you want to install
+#
+
+CFLAGS ?= -O2
+CC = gcc $(CFLAGS)
+PYTHON = python2 -m py_compile
+GZIP = gzip
+
+PREFIX ?= /usr
+DESTDIR ?= # root dir
+
+CFLAGS += -lGL -lX11
+
+sharedir := $(DESTDIR)$(PREFIX)/share
+bindir := $(DESTDIR)$(PREFIX)/bin
+
+all: build
+
+clean:
+	$(RM) ./python/*.pyc
+	$(RM) ./python/lib/*.pyc
+	$(RM) ./bin/check_dd
+	$(RM) ./bin/playonlinux
+	$(RM) ./bin/playonlinux-pkg
+	$(RM) ./ChangeLog
+
+build:
+	$(CC) ./src/check_direct_rendering.c -o ./bin/check_dd
+	$(PYTHON) ./python/*.py
+	$(PYTHON) ./python/lib/*.py
+	echo -e '#!/bin/bash\n${sharedir}/playonlinux/playonlinux "$$@"\nexit 0' > ./bin/playonlinux
+	echo -e '#!/bin/bash\n${sharedir}/playonlinux/playonlinux-pkg "$$@"\nexit 0' > ./bin/playonlinux-pkg
+	chmod +x ./bin/playonlinux
+	chmod +x ./bin/playonlinux-pkg
+
+install:
+	install -d $(bindir)
+	install -d $(sharedir)/pixmaps
+	install -d $(sharedir)/applications
+	install -d $(sharedir)/playonlinux/bin
+	install -d $(sharedir)/man/man1
+	$(GZIP) -c ./doc/playonlinux-pkg.1 > $(sharedir)/man/man1/playonlinux-pkg.1.gz
+	$(GZIP) -c ./doc/playonlinux.1 > $(sharedir)/man/man1/playonlinux.1.gz
+	cp ./etc/PlayOnLinux.desktop $(sharedir)/applications/PlayOnLinux.desktop
+	cp ./etc/playonlinux.png $(sharedir)/pixmaps/playonlinux.png
+	cp ./etc/playonlinux16.png $(sharedir)/pixmaps/playonlinux16.png
+	cp ./etc/playonlinux32.png $(sharedir)/pixmaps/playonlinux32.png
+	cp ./bin/{playonlinux,playonlinux-pkg} $(bindir)/
+	cp ./{playonlinux*,README.md,TRANSLATORS,CHANGELOG.md,LICENCE} $(sharedir)/playonlinux/
+	cp -R ./{bash,etc,lang,lib,plugins,python,resources,tests} $(sharedir)/playonlinux/
+
+changelog:
+	(GIT_DIR=.git git log > .changelog.tmp && mv .changelog.tmp ChangeLog; rm -f .changelog.tmp) || (touch ChangeLog; echo 'git directory not found: installing possibly empty changelog.' >&2)
+
+.PHONY: all clean build install changelog

--- a/bash/check_gl
+++ b/bash/check_gl
@@ -41,18 +41,24 @@ Check_OpenGL()
 		chmod +x "$POL_USER_ROOT/tmp/check_dd_$1"
 		message="$("$POL_USER_ROOT/tmp/check_dd_$1")"
 		out="$?"
-		
-		if [ "$out" = "0" ]
-		then
-			$cmd "$message"
-			exit 0
-		else
-			$cmdW "$message"
-			exit 2
-		fi
+	# When bz2 version is not presented (was installed on specific platform)
+	# use on site compiled check_dd version
+	elif [ -e "/usr/libexec/playonlinux-check_dd" ]
+	then
+		message="$("/usr/libexec/playonlinux-check_dd")"
+		out="$?"
 	else
 		$cmdW "check_dd_$1 missing, test skipped"
 		exit 0
+	fi
+
+	if [ "$out" = "0" ]
+	then
+		$cmd "$message"
+		exit 0
+	else
+		$cmdW "$message"
+		exit 2
 	fi
 }
 cd /tmp


### PR DESCRIPTION
Add Makefile to build and install the POL.
Build command will compile py to pyc and compile ``./src/check_direct_rendering.c`` to ``./bin/check_dd``.
Install command will install files to given prefix.
Change the ``check_gl`` script to use compiled ``check_dd`` as fallback when bz2 files missing.