### PR TITLE
Install lang files correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,8 @@ build:
 	echo -e '#!/bin/bash\n${sharedir}/playonlinux/playonlinux-pkg "$$@"\nexit 0' > ./bin/playonlinux-pkg
 	chmod +x ./bin/playonlinux
 	chmod +x ./bin/playonlinux-pkg
+	sed -i 's/\(\["DEBIAN_PACKAGE"\]\s*=\s*\)"FALSE"/\1"TRUE"/' \
+		./python/lib/Variables.py
 
 install:
 	install -d $(bindir)
@@ -61,6 +63,7 @@ install:
 	install -d $(sharedir)/applications
 	install -d $(sharedir)/playonlinux/bin
 	install -d $(sharedir)/man/man1
+	install -d $(sharedir)/locale
 	$(GZIP) -c ./doc/playonlinux-pkg.1 > $(sharedir)/man/man1/playonlinux-pkg.1.gz
 	$(GZIP) -c ./doc/playonlinux.1 > $(sharedir)/man/man1/playonlinux.1.gz
 	cp ./etc/PlayOnLinux.desktop $(sharedir)/applications/PlayOnLinux.desktop
@@ -70,7 +73,8 @@ install:
 	cp ./bin/{playonlinux,playonlinux-pkg} $(bindir)/
 	cp ./bin/playonlinux-check_dd $(execdir)/
 	cp ./{playonlinux*,README.md,TRANSLATORS,CHANGELOG.md,LICENCE} $(sharedir)/playonlinux/
-	cp -R ./{bash,etc,lang,lib,plugins,python,resources,tests} $(sharedir)/playonlinux/
+	cp -R ./{bash,etc,lib,plugins,python,resources,tests} $(sharedir)/playonlinux/
+	cp -R ./lang/locale/* $(sharedir)/locale/
 
 changelog:
 	(GIT_DIR=.git git log > .changelog.tmp && mv .changelog.tmp ChangeLog; rm -f .changelog.tmp) || (touch ChangeLog; echo 'git directory not found: installing possibly empty changelog.' >&2)


### PR DESCRIPTION
To use installed locales in ``/usr/share/locale`` the ``DEBIAN_PACKAGE`` value must be set to true.

Also it will disable updates alert, bug reports and statistics. It should also use good msstcorefonts.

I see this as the best way how to install on a system with make install but I think it will be better when this won't disable statistics and bug reports. These features could be usable even for normally installed system.