### PR TITLE
Fix bad icon path in Desktop file

### DIFF
--- a/etc/PlayOnLinux.desktop
+++ b/etc/PlayOnLinux.desktop
@@ -4,5 +4,5 @@ Name=PlayOnLinux
 Comment=Front-end application for the wine
 Type=Application
 Exec=playonlinux %F
-Icon=/usr/share/playonlinux/etc/playonlinux.png
+Icon=/usr/share/pixmaps/playonlinux.png
 Categories=Utility;Emulator;


### PR DESCRIPTION
Icon should be used from /usr/share/pixmaps not from application folder.
