### PR TITLE
Do not use hardcoded icon path in desktop file

### DIFF
--- a/etc/PlayOnLinux.desktop
+++ b/etc/PlayOnLinux.desktop
@@ -4,5 +4,5 @@ Name=PlayOnLinux
 Comment=Front-end application for the wine
 Type=Application
 Exec=playonlinux %F
-Icon=/usr/share/pixmaps/playonlinux.png
+Icon=playonlinux
 Categories=Utility;Emulator;


### PR DESCRIPTION
There is absolutely no need to have a hardcoded icon path in the desktop file if the icon is installed in a standard location. Using a hardcoded icon path (even if it points to a standard location) is not recommended as it doesn't allow users to use custom icons for the application and can have other negative side effects.

The non-hardcoded path is already used, for example, by the [PlayOnLinux.directory](https://github.com/PlayOnLinux/POL-POM-4/blob/master/etc/PlayOnLinux.directory) file created by @qparis.