### PR TITLE
Fixed Makefile to work with -Wl,--as-needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,6 @@ GZIP = gzip
 PREFIX ?= /usr
 DESTDIR ?= # root dir
 
-CFLAGS += -lGL -lX11
-
 sharedir := $(DESTDIR)$(PREFIX)/share
 bindir := $(DESTDIR)$(PREFIX)/bin
 execdir := $(DESTDIR)$(PREFIX)/libexec
@@ -46,7 +44,7 @@ clean:
 	$(RM) ./ChangeLog
 
 build:
-	$(CC) ./src/check_direct_rendering.c -o ./bin/playonlinux-check_dd
+	$(CC) ./src/check_direct_rendering.c -o ./bin/playonlinux-check_dd -lGL -lX11
 	$(PYTHON) ./python/*.py
 	$(PYTHON) ./python/lib/*.py
 	echo -e '#!/bin/bash\nGDK_BACKEND=x11 ${sharedir}/playonlinux/playonlinux "$$@"\nexit 0' > ./bin/playonlinux


### PR DESCRIPTION
If the user's `LDFLAGS` include `Wl,--as-needed` then the build fails because `-lGL -lX11` is included in `CFLAGS` and therefore appears before the source file when gcc is invoked, causing them to be filtered out by `--as-needed`. Since gcc is only invoked once in the Makefile, the easiest solution seemed to be just adding `-lGL -lX11` to the end of the line that calls it.

Also note that it might be better to invoke `cc` instead of `gcc` or to use the `CC` environment variable, unless the program is incompatible with other compilers such as clang.

Error produced by the current Makefile, fixed by this PR, is below (note the order of the arguments to `gcc`):
```
gcc -O2 -pipe -march=haswell -Wl,-O1 -Wl,--as-needed -Wl,-z,now -Wl,-z,relro -lGL -lX11 ./src/check_direct_rendering.c -o ./bin/playonlinux-check_dd
/var/tmp/portage/app-emulation/playonlinux-4.2.11/temp/ccEoJYO5.o: In function `main':
check_direct_rendering.c:(.text.startup+0x28): undefined reference to `XOpenDisplay'
check_direct_rendering.c:(.text.startup+0xe4): undefined reference to `glXChooseVisual'
check_direct_rendering.c:(.text.startup+0x102): undefined reference to `glXCreateContext'
check_direct_rendering.c:(.text.startup+0x112): undefined reference to `glXIsDirect'
check_direct_rendering.c:(.text.startup+0x169): undefined reference to `XFree'
check_direct_rendering.c:(.text.startup+0x182): undefined reference to `glXChooseVisual'
```
whereas
```
gcc -O2 -pipe -march=haswell -Wl,-O1 -Wl,--as-needed -Wl,-z,now -Wl,-z,relro ./src/check_direct_rendering.c -o ./bin/playonlinux-check_dd -lGL -lX11
```
as produced by the PR version, works fine.