### PR TITLE
add /usr/bin/python path to list of next_python interpreter search

### DIFF
--- a/bash/find_python
+++ b/bash/find_python
@@ -17,6 +17,7 @@ search_python () {
 		next_python "python2.7"
 		next_python "python2.6"
 		next_python "python2"
+		next_python "/usr/bin/python"
 		next_python "none"
 	
 		if [ "$POL_PYTHON" = "none" ]; then


### PR DESCRIPTION
Hard code python path when searching for interpreters as a workaround for 'Please install python' error when attempting to launch POL.