### PR TITLE
Do not crash on "make install" if /bin/sh is dash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ CFLAGS ?= -O2
 CC = gcc $(CFLAGS)
 PYTHON = python2 -m py_compile
 GZIP = gzip
+SHELL := /bin/bash
 
 PREFIX ?= /usr
 DESTDIR ?= # root dir


### PR DESCRIPTION
Summary:

I tried "make install" on Mint but /bin/sh was dash so certain types of globbing failed to expand during "make install".

Reproducing:

Be on a distro where /bin/sh is dash not bash and try "make install". 

Eventually you will see:

cp ./etc/playonlinux.png /opt/PlayOnLinux/share/pixmaps/playonlinux.png
cp ./etc/playonlinux16.png /opt/PlayOnLinux/share/pixmaps/playonlinux16.png
cp ./etc/playonlinux32.png /opt/PlayOnLinux/share/pixmaps/playonlinux32.png
cp ./bin/{playonlinux,playonlinux-pkg} /opt/PlayOnLinux/bin/
cp: cannot stat './bin/{playonlinux,playonlinux-pkg}': No such file or directory
Makefile:58: recipe for target 'install' failed

That is because "{one,two}" is not expanded by dash.