### PR TITLE
set bash history to unlimited

### DIFF
--- a/etc/pol_bash
+++ b/etc/pol_bash
@@ -24,6 +24,9 @@ export HISTCONTROL=ignoredups
 # ... and ignore same sucessive entries.
 export HISTCONTROL=ignoreboth
 
+# do not limit bash history size
+export HISTSIZE=-1
+
 # check the window size after each command and, if necessary,
 # update the values of LINES and COLUMNS.
 shopt -s checkwinsize


### PR DESCRIPTION
prevents cutting ~/.bash_history to 500 lines every time we open a
shell