### PR TITLE
Fix version split

### DIFF
--- a/python/lib/playonlinux.py
+++ b/python/lib/playonlinux.py
@@ -278,11 +278,11 @@ def VersionLower(version1, version2):
         else:
             return False
 
-    version1 = [ int(digit) for digit in version1[0].split(".") ]
+    version1 = [ int(digit) for digit in version1[0].split(".")[:3] ]
     while len(version1) < 3:
         version1.append(0)
 
-    version2 = [ int(digit) for digit in version2[0].split(".") ]
+    version2 = [ int(digit) for digit in version2[0].split(".")[:3] ]
     while len(version2) < 3:
         version2.append(0)
 


### PR DESCRIPTION
```
$ ./playonlinux
Looking for python3... 3.8.5 - selected
Traceback (most recent call last):
  File "mainwindow.py", line 39, in <module>
    import lib.lng as lng
  File "/home/rayder/Projects/archlinux/builds/playonlinux/python/lib/lng.py", line 6, in <module>
    from . import Variables
  File "/home/rayder/Projects/archlinux/builds/playonlinux/python/lib/Variables.py", line 50, in <module>
    if playonlinux.VersionLower(wx.VERSION_STRING, "3.0.0"):
  File "/home/rayder/Projects/archlinux/builds/playonlinux/python/lib/playonlinux.py", line 281, in VersionLower
    version1 = [ int(digit) for digit in version1[0].split(".") ]
  File "/home/rayder/Projects/archlinux/builds/playonlinux/python/lib/playonlinux.py", line 281, in <listcomp>
    version1 = [ int(digit) for digit in version1[0].split(".") ]
ValueError: invalid literal for int() with base 10: 'post2'
```

Some version can contain not only digits, for example wx versions:
- 4.0.7
- 4.0.7.post1
- 4.0.7.post2
- 4.1.0
