### PR TITLE
Workaround to non-numeric characters in lists version1 and version2

### DIFF
--- a/python/lib/playonlinux.py
+++ b/python/lib/playonlinux.py
@@ -278,11 +278,17 @@ def VersionLower(version1, version2):
         else:
             return False
 
-    version1 = [ int(digit) for digit in version1[0].split(".")[:3] ]
+    try:
+        version1 = [ int(digit) for digit in version1[0].split(".") ]
+    except ValueError:
+        version1 = [ int(digit) for digit in version1[0].split(".") if digit.isnumeric() ]
     while len(version1) < 3:
         version1.append(0)
 
-    version2 = [ int(digit) for digit in version2[0].split(".")[:3] ]
+    try:
+        version2 = [ int(digit) for digit in version2[0].split(".") ]
+    except ValueError:
+        version2 = [ int(digit) for digit in version2[0].split(".") if digit.isnumeric() ]
     while len(version2) < 3:
         version2.append(0)
 

--- a/python/lib/playonlinux.py
+++ b/python/lib/playonlinux.py
@@ -278,17 +278,11 @@ def VersionLower(version1, version2):
         else:
             return False
 
-    try:
-        version1 = [ int(digit) for digit in version1[0].split(".") ]
-    except ValueError:
-        version1 = [ int(digit) for digit in version1[0].split(".") if digit.isnumeric() ]
+    version1 = [ int(digit) for digit in version1[0].split(".") if digit.isnumeric() ]
     while len(version1) < 3:
         version1.append(0)
 
-    try:
-        version2 = [ int(digit) for digit in version2[0].split(".") ]
-    except ValueError:
-        version2 = [ int(digit) for digit in version2[0].split(".") if digit.isnumeric() ]
+    version2 = [ int(digit) for digit in version2[0].split(".") if digit.isnumeric() ]
     while len(version2) < 3:
         version2.append(0)
 


### PR DESCRIPTION
adding `isnumeric()` function to check if digit has non-numeric characters, to avoid `ValueError` raised when version have strings within (i.e: 4.0.0.post2), and to avoid cut the list without check it.