### PR TITLE
Fix Mac WINE VersionFetcher and bump versioning to 4.4.3

### DIFF
--- a/python/lib/Variables.py
+++ b/python/lib/Variables.py
@@ -17,7 +17,7 @@ except:
 os.environ["POL_PORT"] = "0"
 os.environ["PLAYONLINUX"] = os.path.realpath(os.path.realpath(__file__)+"/../../../")
 os.environ["SITE"] = "http://repository.playonlinux.com"
-os.environ["VERSION"] = "4.4.1"
+os.environ["VERSION"] = "4.4.3"
 os.environ["POL_ID"] = str(random.randint(1, 100000000))
 os.environ["GECKO_SITE"] = "http://wine.playonlinux.com/gecko"
 os.environ["MONO_SITE"] = "http://wine.playonlinux.com/mono"
@@ -39,6 +39,7 @@ if os.environ["POL_OS"] == "Mac":
     windows_add_playonmac = 1
     widget_borders = wx.SIMPLE_BORDER
     os_name = "darwin"
+    ca_file = '../../lib/python3.8/certifi/cacert.pem' 
     os.environ["POL_WGET"] = "wget --prefer-family=IPv4 -q --no-check-certificate"
 
 # Variables PlayOnLinux
@@ -119,7 +120,7 @@ if os.environ["POL_OS"] == "Mac":
 
     os.environ["PATH"] = os.environ["PLAYONLINUX"]+"/../unix/wine/bin:" + os.environ["PLAYONLINUX"]+"/../unix/image_magick/bin:" + os.environ["PLAYONLINUX"]+"/../unix/tools/bin/:" + os.environ["PATH"]
 
-    os.environ["WRITE_LD"] = os.environ["LD_LIBRARY_PATH"]
+    os.environ["WRITE_LD"] = os.environ["LD_LIBRARY_PATH"] + ":" + os.environ["PLAYONLINUX"]+"/../unix/wine/lib"
     os.environ["DYLD_FALLBACK_LIBRARY_PATH"] =  os.environ["PLAYONLINUX"]+"/../unix/wine/lib"
     os.environ["WRITE_DYLD_FALLBACK_LIBRARY_PATH"] =  os.environ["PLAYONLINUX"]+"/../unix/wine/lib"
     os.environ["FREETYPE_PROPERTIES"]="truetype:interpreter-version=35"

--- a/python/wine_versions/WineVersionsFetcher.py
+++ b/python/wine_versions/WineVersionsFetcher.py
@@ -18,10 +18,13 @@ class WineVersionFetcher():
 
     def _sync_fetch_all_available_wine_versions(self, callback, error):
         wine_version_url = "https://phoenicis.playonlinux.com/index.php/wine?os=%s" % self.operating_system
-        print("Donwloading %s " % wine_version_url)
+        print("Downloading %s " % wine_version_url)
         try:
             request = urllib.request.Request(wine_version_url, None, {'User-Agent': Variables.userAgent})
-            handle = urllib.request.urlopen(request, timeout=5)
+            if self.operating_system == 'darwin':
+                handle = urllib.request.urlopen(request, cafile='../../lib/python3.8/certifi/cacert.pem', timeout=5)
+            else:
+                handle = urllib.request.urlopen(request, timeout=5)
             callback(self._convert_phoenicis_wine_versions_to_v4(json.load(handle)))
         except Exception as e:
             error(traceback.format_exc())


### PR DESCRIPTION
This has been a longstanding bug with several issues open, as well as several forum posts.  The problem seems to stem from not using the certifi certificate authority file properly when fetching wine versions.  At some point the sites swapped to using a CA that was "unknown".  

This Patch should only impact Mac OSX, as I did not want to impact Linux with the fix, although the problem may occur on linux as well - I just haven't tested.  I have been using this patch for almost 2 years now.

This is a significant enough fix, that may warrant building 4.4.4 so users can continue enjoying playing games on OSX.  