### PR TITLE
Fixed debug message in POL_Wine_SetVersionEnv to log using POL_Debug_Message

### DIFF
--- a/lib/wine.lib
+++ b/lib/wine.lib
@@ -837,7 +837,7 @@ POL_Wine_SetVersionEnv() {
         POL_Wine_InstallVersion "$POL_WINEVERSION"
         [[ "$?" == 2 ]] && return 0
       fi
-      echo "Setting paths..."
+      POL_Debug_Message "Setting paths..."
       export PATH="$WINEDIR/$POL_WINEVERSION/bin/:$PATH"
       [ "$POL_OS" = "Mac" ] && export DYLD_FALLBACK_LIBRARY_PATH="$WINEDIR/$POL_WINEVERSION/lib/"
       export FREETYPE_PROPERTIES="truetype:interpreter-version=35"


### PR DESCRIPTION
This appears to be a log message that was accidentally added to be using `echo` instead of `POL_Debug_Message`.

As such, it got pulled into output strings when subshells called `POL_Wine_SetVersionEnv`. For example, when running the [Microsoft Office 2016 (Method B)](https://www.playonlinux.com/en/app-4203-Microsoft_Office_2016_method_B.html) script, this line:
```
cp "$WINEPREFIX/drive_c/$PROGRAMFILES/Common Files/Microsoft Shared/ClickToRun/AppvIsvSubsystems32.dll" "$WINEPREFIX/drive_c/$PROGRAMFILES/Microsoft Office/root/Office16/"
```
errors out with:
```
cp: cannot stat '/home/trottel/.PlayOnLinux//wineprefix/Office2016/drive_c/ting paths...C:\Program Files/Common Files/Microsoft Shared/ClickToRun/AppvIsvSubsystems32.dll': No such file or directory
```
Note the `.../drive_c/ting paths...C:\...` part lol.

The `"Set"` prefix is stripped in `export PROGRAMFILES="${PROGRAMFILES:3}"` within [`POL_LoadVar_PROGRAMFILES`](https://github.com/PlayOnLinux/POL-POM-4/blob/master/lib/wine.lib#L347C44-L347C44).

This also caused issue when using file associations because it seemed to try to open files. It would somehow try to open a file with name `Setting paths... Z:\...`.

Manually replacing `echo` with `POL_Debug_Message` fixed both issues.