### PR TITLE
In Debian 12 the which command has been removed to submit patches.

### DIFF
--- a/bash/find_python
+++ b/bash/find_python
@@ -26,7 +26,7 @@ search_python () {
 		fi                   
 	
 		echo -n "Looking for $POL_PYTHON... " 1>&2
-		if [ "$(which $POL_PYTHON)" ]; then
+		if [ "$(command -v $POL_PYTHON)" ]; then
 			local Version=$($POL_PYTHON --version 2>&1 |tail -n 1|sed -e 's/^Python //')
 			echo -n "$Version - " 1>&2
 			case "$Version" in

--- a/lib/playonlinux.lib
+++ b/lib/playonlinux.lib
@@ -916,16 +916,16 @@ POL_Sudo()
 		fi
 		if [ "$POL_OS" = "Linux" ]; then
 			# Now, we detect what sudo to use
-			if which gksudo; then
+			if command -v gksudo; then
 				SUDO_COMMAND="gksudo --"
 				unset gksudo
-			elif which gksu; then
+			elif command -v gksu; then
 				SUDO_COMMAND="gksu --"
 				unset gksu
-			elif which kdesu; then
+			elif command -v kdesu; then
 				SUDO_COMMAND="kdesu --"
 				unset kdesu
-			elif which sudo; then
+			elif command -v sudo; then
 				SUDO_COMMAND="$POL_TERM -e sudo"
 				unset sudo
 			else

--- a/lib/scripts.lib
+++ b/lib/scripts.lib
@@ -737,7 +737,7 @@ POL_System_ExtractSingleFile ()
     local archivename=`basename "$archive"`
     local filename=`basename "$file"`
     local szpid
-    local szip=`which 7z`
+    local szip=`command -v 7z`
 
     POL_Debug_Message "Extracting single file : \"$archive\", \"$file\", \"$dest\""
 

--- a/lib/variables
+++ b/lib/variables
@@ -31,7 +31,7 @@ POL_Config_pRead (){ cat "$POL_USER_ROOT/playonlinux.cfg" 2> /dev/null | grep "^
 alias find="find -H"
 
 ### Security feature
-[ "$(which sudo)" ] && sudo -k 2> /dev/null
+[ "$(command -v sudo)" ] && sudo -k 2> /dev/null
 
 ### Terminal
 # User override, must support -T to set title and -e to run a command
@@ -53,7 +53,7 @@ fi
 export POL_TERM
 
 ### Desktop
-[ "$(which xdg-user-dir)" ] && export DESKTOP="$(xdg-user-dir DESKTOP)" || export DESKTOP="$HOME/Desktop"
+[ "$(command -v xdg-user-dir)" ] && export DESKTOP="$(xdg-user-dir DESKTOP)" || export DESKTOP="$HOME/Desktop"
 
 ### Override ~/.wgetrc
 export WGETRC="$POL_USER_ROOT/configurations/wgetrc"
@@ -70,7 +70,7 @@ else
 	eval_gettext() { printf "$@"; }
 fi
 
-which shasum > /dev/null 2> /dev/null || shasum () { sha1sum "$@"; }
+command -v shasum > /dev/null 2> /dev/null || shasum () { sha1sum "$@"; }
 
 
 if [ "$POL_OS" == "Linux" ]

--- a/lib/wine.lib
+++ b/lib/wine.lib
@@ -989,7 +989,7 @@ POL_Wine_PrefixCreate() {
 
       POL_Debug_InitPrefix
 
-      command -v wineprefixcreate && [ "$(POL_MD5_file "$(which wineprefixcreate)")" != "5c0ee90682746e811698a53415b4765d" ] && [ ! "$(which wineprefixcreate | grep $APPLICATION_TITLE)" = "" ] && wine wineprefixcreate
+      command -v wineprefixcreate && [ "$(POL_MD5_file "$(command -v wineprefixcreate)")" != "5c0ee90682746e811698a53415b4765d" ] && [ ! "$(command -v wineprefixcreate | grep $APPLICATION_TITLE)" = "" ] && wine wineprefixcreate
       wine wineboot
     fi
   fi

--- a/lib/wine.lib
+++ b/lib/wine.lib
@@ -989,13 +989,13 @@ POL_Wine_PrefixCreate() {
 
       POL_Debug_InitPrefix
 
-      which wineprefixcreate && [ "$(POL_MD5_file "$(which wineprefixcreate)")" != "5c0ee90682746e811698a53415b4765d" ] && [ ! "$(which wineprefixcreate | grep $APPLICATION_TITLE)" = "" ] && wine wineprefixcreate
+      command -v wineprefixcreate && [ "$(POL_MD5_file "$(which wineprefixcreate)")" != "5c0ee90682746e811698a53415b4765d" ] && [ ! "$(which wineprefixcreate | grep $APPLICATION_TITLE)" = "" ] && wine wineprefixcreate
       wine wineboot
     fi
   fi
 
   # Make sure that .reg files are created
-  if which wineserver; then
+  if command -v wineserver; then
     wineserver -w
   else
     POL_Debug_Message "Warning, wineserver not found"

--- a/python/mainwindow.py
+++ b/python/mainwindow.py
@@ -27,7 +27,7 @@ import sys
 import time
 import urllib.parse
 import webbrowser
-import shtil
+import shutil
 
 try:
     os.environ["POL_OS"]

--- a/python/mainwindow.py
+++ b/python/mainwindow.py
@@ -27,6 +27,7 @@ import sys
 import time
 import urllib.parse
 import webbrowser
+import shtil
 
 try:
     os.environ["POL_OS"]

--- a/python/mainwindow.py
+++ b/python/mainwindow.py
@@ -1216,7 +1216,8 @@ class PlayOnLinuxApp(wx.App):
     def _executableFound(self, executable):
         devnull = open('/dev/null', 'wb')
         try:
-            returncode = subprocess.call(["which", executable], stdout=devnull)
+            executable_path = shutil.which(executable)
+            returncode = subprocess.call(executable_path, stdout=devnull)
             return (returncode == 0)
         except:
             return False


### PR DESCRIPTION
Patch function execution error caused by the deletion of the which command in Debian 12.

Currently, only Debian 12 has removed the which command, but I suspect it will be removed in many future distributions as well.

Accordingly, we submit a patch that applies commands that can be used equally in many operating systems as well as Debian.

Please apply the patch.