### PR TITLE
Remove unused import of deprecated Python asyncore.dispatcher

### DIFF
--- a/python/options.py
+++ b/python/options.py
@@ -18,7 +18,6 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from asyncore import dispatcher
 import os, subprocess, getopt, sys, urllib.request, signal, socket
 import wx, time, re
 import webbrowser, shutil


### PR DESCRIPTION
Using Python 3.12 (e.g. on Fedora 40), PlayOnLinux 4.4 fails during startup like this:

```
$ playonlinux
Looking for python3... 3.12.3 - selected
/usr/share/playonlinux/python/mainwindow.py:708: SyntaxWarning: invalid escape sequence '\|'
  self.SupprotedIconExt = "All|*.xpm;*.XPM;*.png;*.PNG;*.ico;*.ICO;*.jpg;*.JPG;*.jpeg;*.JPEG;*.bmp;*.BMP\
1.0
Traceback (most recent call last):
  File "/usr/share/playonlinux/python/mainwindow.py", line 41, in <module>
    import options, threading, debug
  File "/usr/share/playonlinux/python/options.py", line 21, in <module>
    from asyncore import dispatcher
ModuleNotFoundError: No module named 'asyncore'
```

Interestingly, PlayOnLinux doesn't seem to use the deprecated Python asyncore.dispatcher other than importing it…at least I can not find any occurrence in the code that it would actually use the Python module after reading https://docs.python.org/3.11/library/asyncore.html#asyncore.dispatcher. This matches my experience that PlayOnLinux seems to still work properly when having this import line just removed.