### PR TITLE
Return based on shutil.which() instead of subprocess.call()

### DIFF
--- a/python/mainwindow.py
+++ b/python/mainwindow.py
@@ -1215,11 +1215,8 @@ class PlayOnLinuxApp(wx.App):
         return True
 
     def _executableFound(self, executable):
-        devnull = open('/dev/null', 'wb')
         try:
-            executable_path = shutil.which(executable)
-            returncode = subprocess.call(executable_path, stdout=devnull)
-            return (returncode == 0)
+            return (shutil.which(executable) is not None)
         except:
             return False
 


### PR DESCRIPTION
Fix https://github.com/PlayOnLinux/POL-POM-4/pull/71#pullrequestreview-2079773928, because it's incorrect to evaluate the exit code from calling e.g. `/usr/bin/nc`, which might be `2` and thus leading to `False`, instead of checking whether the desired executable actually exists.