### PR TITLE
Replace pipes.quote() from deprecated Python pipes

### DIFF
--- a/python/lib/playonlinux.py
+++ b/python/lib/playonlinux.py
@@ -5,7 +5,7 @@
 
 from . import Variables
 import os
-import subprocess, shlex, pipes, wx
+import subprocess, shlex, wx
 import natsort
 
 def winpath(script, path):
@@ -373,7 +373,7 @@ def getArgs(shortcut): # Get prefix name from shortcut
     try:
         args = shlex.split(fichier[i])[2:-1]
         #print args
-        args = " ".join([ pipes.quote(x) for x in args])
+        args = " ".join([ shlex.quote(x) for x in args])
         #print args
     except:
         args = ""
@@ -432,7 +432,7 @@ def writeArgs(game, args):
                 old_string = shlex.split(fichier[i])
                 new_string = shlex.split(str(args))
                 new_string = old_string[0:2] + new_string
-                new_string = " ".join([ pipes.quote(x) for x in new_string])
+                new_string = " ".join([ shlex.quote(x) for x in new_string])
 
                 new_string = new_string+' "$@"'
                 line.append(new_string)


### PR DESCRIPTION
Using Python 3.13 (e.g. on Fedora 41), PlayOnLinux 4.4 fails during startup like this:

```
$ playonlinux
Looking for python3... 3.13.0 - selected
/usr/share/playonlinux/python/mainwindow.py:709: SyntaxWarning: invalid escape sequence '\|'
  self.SupprotedIconExt = "All|*.xpm;*.XPM;*.png;*.PNG;*.ico;*.ICO;*.jpg;*.JPG;*.jpeg;*.JPEG;*.bmp;*.BMP\
Traceback (most recent call last):
  File "/usr/share/playonlinux/python/mainwindow.py", line 40, in <module>
    import lib.lng as lng
  File "/usr/share/playonlinux/python/lib/lng.py", line 6, in <module>
    from . import Variables
  File "/usr/share/playonlinux/python/lib/Variables.py", line 6, in <module>
    import wx, lib.playonlinux as playonlinux
  File "/usr/share/playonlinux/python/lib/playonlinux.py", line 8, in <module>
    import subprocess, shlex, pipes, wx
ModuleNotFoundError: No module named 'pipes'
```

https://docs.python.org/3/library/shlex.html warns that the `shlex` module is only designed for Unix shells, which should be fine for PlayOnLinux (and even PlayOnMac) as it is not supposed to be run under Windows, right?