### PR TITLE
Fix Syntax: invalid escape sequence

### DIFF
--- a/python/configurewindow/ConfigureWindowNotebook.py
+++ b/python/configurewindow/ConfigureWindowNotebook.py
@@ -461,8 +461,8 @@ class ConfigureWindowNotebook(wx.Notebook):
             self.FileDialog = wx.FileDialog(self)
             self.FileDialog.SetDirectory("~")
             self.supported_files = "All|*.exe;*.EXE;*.msi;*.MSI\
-            \|Windows executable (*.exe)|*.exe;*.EXE\
-            \|Windows install file (*.msi)|*.msi;*MSI"
+            |Windows executable (*.exe)|*.exe;*.EXE\
+            |Windows install file (*.msi)|*.msi;*MSI"
             self.FileDialog.SetWildcard(self.supported_files)
             self.FileDialog.ShowModal()
             if (self.FileDialog.GetPath() != ""):


### PR DESCRIPTION
This will fix
```
/usr/share/playonlinux4/python/configurewindow/ConfigureWindowNotebook.py:463: SyntaxWarning: invalid escape sequence '\|'
  self.supported_files = "All|*.exe;*.EXE;*.msi;*.MSI\
[main] Message: PlayOnLinux (4.4.3) is starting

```