### PR TITLE
Remove user agent setting for URLopener

### DIFF
--- a/python/setupwindow/POL_SetupFrame.py
+++ b/python/setupwindow/POL_SetupFrame.py
@@ -33,7 +33,6 @@ import lib.lng
 import lib.playonlinux as playonlinux
 
 lib.lng.Lang()
-urllib.request.URLopener.version = Variables.userAgent  # Arg ...
 
 from ui.PlayOnLinuxWindow import PlayOnLinuxWindow
 from setupwindow.Downloader import Downloader


### PR DESCRIPTION
Remove setting user agent for URLopener.

The Variables.userAgent attribute doesn't even exist anymore, and URLopener was removed in Python 3.13. This line was setting a user-agent on a long-deprecated class. The simplest fix is to remove it — it's dead code.